### PR TITLE
Normalize accessionId to uppercase in search and initialization

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -140,7 +140,7 @@ window.data = {
   // Search
   accessionId: null,
   searchByAccessionId() {
-    navigateTo(`/transaction-logs?accessionId=${this.accessionId}`)
+    navigateTo(`/transaction-logs?accessionId=${this.accessionId?.toUpperCase()}`)
   }
 }
 

--- a/js/transaction-logs.js
+++ b/js/transaction-logs.js
@@ -25,7 +25,7 @@ export default () => {
 
     async init() {
       const queryParams = getQueryParams()
-      this.accessionId = queryParams.accessionId
+      this.accessionId = queryParams.accessionId?.toUpperCase()
       Alpine.store('title').set(`Transaction Logs for ${this.accessionId}`)
       const transactionLogs = await getTransactionLogs(this.accessionId)
       if (transactionLogs.errors === undefined) {


### PR DESCRIPTION
  - Normalize accession ID to uppercase on the Transaction Logs page so that lowercase input (e.g. `38772-voy-4462816174`) returns all events, not just the initial "Order created" entry
                                                                                                                                                                                                                
 - Follow-up events (external requests, results) are stored with the uppercase accession ID returned by the external lab. A case-sensitive lookup on a lowercase input missed them.
                                                                                                                                                                                                                 
  ### Fix          

  - `js/main.js` — uppercase before navigating to `/transaction-logs`
  - `js/transaction-logs.js` — uppercase when reading from URL query params (covers direct navigation)                                                                                                           
                                                                                                      
  Closes #98                                                                                                                                                                                                     
