### PR TITLE
Use UTC for date formatting in dataPointSelection event

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -29,7 +29,7 @@ export const dashboard = () => {
             events: {
               dataPointSelection: function (event, chartContext, opts) {
                 const provider = opts.w.config.series[opts.seriesIndex].id
-                const date = moment(opts.w.config.series[opts.seriesIndex].data[opts.dataPointIndex].x)
+                const date = moment.utc(opts.w.config.series[opts.seriesIndex].data[opts.dataPointIndex].x)
                 navigateTo(`/external-requests?provider=${provider}&date=${date.format('MM/DD/YYYY')}&status=4xx,5xx`)
               },
               dataPointMouseEnter: function (event) {


### PR DESCRIPTION
  ## Root Cause                                                                                                                                                                                                  
                                                                                                                                                                                                               
  `formatDateInLocalTimezone` (date-utils.js) formats a date in local time but appends a literal `Z` suffix, making the resulting string look like a UTC timestamp when it isn't.
`createTimeSeries` stores these as `new Date(ts.x)`, which the browser parses as midnight **UTC**. ApexCharts renders datetime axes in UTC by default, so the chart *looks* correct, but the click handler wrapped the same Date in `moment()` (local mode), shifting it back by the user's UTC offset and landing on the previous day.

  ## Fix

Use `moment.utc()` instead of `moment()` in the `dataPointSelection` handler in `dashboard.js` so the date is read from the UTC representation, which matches the intended local date.

Closes #100