### PR TITLE
Add continue option when batch test fails

### DIFF
--- a/js/constants/integrations-config.js
+++ b/js/constants/integrations-config.js
@@ -2,16 +2,16 @@ export const INTEGRATIONS_CONFIG = [
   {
     status: 'RUNNING',
     color: 'green',
-    operations: ['stop', 'restart']
+    operations: ['test', 'stop', 'restart']
   },
   {
     status: 'STOPPED',
     color: 'red',
-    operations: ['start']
+    operations: ['test', 'start']
   },
   {
     status: 'NEW',
     color: 'blue',
-    operations: ['start']
+    operations: ['test', 'start']
   }
 ]

--- a/js/integrations.js
+++ b/js/integrations.js
@@ -133,10 +133,12 @@ export const integrations = {
     data: {
       inProgress: false,
       operation: null,
-      integration: null
+      integration: null,
+      result: null
     },
     onShow: (self, data) => {
       data.error = null
+      data.result = null
       data.inProgress = false
     },
     onHide: (self) => {
@@ -181,14 +183,18 @@ export const integrations = {
       .then(res => {
         data.inProgress = false
         this.table.fetchData()
-        this.actionModal.close()
-        Alpine.store('alert')
-          .set('info', `Integration ${data.integration.id} ${data.operation}${data.operation === 'stop' ? 'p' : ''}ed.`)
+        if (data.operation === 'test') {
+          data.result = { ok: true }
+        } else {
+          this.actionModal.close()
+          Alpine.store('alert')
+            .set('info', `Integration ${data.integration.id} ${data.operation}${data.operation === 'stop' ? 'p' : ''}ed.`)
+        }
       })
       .catch(err => {
         data.inProgress = false
         data.error = {
-          message: err.body.error
+          message: err.body?.error || err.message
         }
       })
   },

--- a/js/integrations.js
+++ b/js/integrations.js
@@ -206,17 +206,18 @@ export const integrations = {
 
     for (const integration of data.integrations) {
       data.currentIntegration = integration
+      const label = `${data.currentIntegration.id} (${data.currentIntegration.practice.name} - ${data.currentIntegration.providerConfiguration.providerId.toUpperCase()})`
       try {
-        const response = await updateIntegrationStatus(data.currentIntegration.id, data.operation)
+        await updateIntegrationStatus(data.currentIntegration.id, data.operation)
         data.logs.push({
           status: 'ok',
-          message: `Integration/${data.currentIntegration.id}: ${response.ok}`
+          message: `${label}: Authentication successful`
         })
         data.done += 1
         data.step = Math.min(data.step + 1, data.integrations.length)
         await delay(500)
       } catch (err) {
-        const errorMessage = `Integration/${data.currentIntegration.id}: ${err.body?.error || err.message}`
+        const errorMessage = `${label}: ${err.body?.error || err.message}`
         data.logs.push({ status: 'error', message: errorMessage })
 
         if (data.operation === 'test') {

--- a/js/integrations.js
+++ b/js/integrations.js
@@ -152,6 +152,8 @@ export const integrations = {
       done: 0,
       step: 0,
       logs: [],
+      awaitingContinue: false,
+      _continueResolver: null,
     },
     onShow: (self, data) => {
       data.inProgress = false
@@ -159,8 +161,15 @@ export const integrations = {
       data.step = 0
       data.done = 0
       data.logs = []
+      data.awaitingContinue = false
+      data._continueResolver = null
     },
     onHide: async (self) => {
+      if (self.data._continueResolver) {
+        self.data._continueResolver(false)
+        self.data._continueResolver = null
+        self.data.awaitingContinue = false
+      }
       await self.table.goToPage(1)
     }
   }),
@@ -187,11 +196,11 @@ export const integrations = {
   async batchIntegrationOperations(data) {
     data.error = null
     data.inProgress = true
+    data.step += 1
 
-    try {
-      data.step += 1
-      for (const integration of data.integrations) {
-        data.currentIntegration = integration
+    for (const integration of data.integrations) {
+      data.currentIntegration = integration
+      try {
         const response = await updateIntegrationStatus(data.currentIntegration.id, data.operation)
         data.logs.push({
           status: 'ok',
@@ -200,19 +209,36 @@ export const integrations = {
         data.done += 1
         data.step = Math.min(data.step + 1, data.integrations.length)
         await delay(500)
-      }
-    } catch (err) {
-      data.inProgress = false
-      data.error = {
-        message: `Integration/${data.currentIntegration.id}: ${err.body.error}`
-      }
-      data.logs.push({
-        status: 'error',
-        message: `Integration/${data.currentIntegration.id}: ${err.body.error}`
-      })
-    } finally {
+      } catch (err) {
+        const errorMessage = `Integration/${data.currentIntegration.id}: ${err.body?.error || err.message}`
+        data.logs.push({ status: 'error', message: errorMessage })
 
+        if (data.operation === 'test') {
+          data.error = { message: errorMessage }
+          const isLast = data.integrations.indexOf(integration) === data.integrations.length - 1
+          if (!isLast) {
+            data.awaitingContinue = true
+            const shouldContinue = await new Promise(resolve => {
+              data._continueResolver = resolve
+            })
+            data.awaitingContinue = false
+            data._continueResolver = null
+            if (!shouldContinue) {
+              data.inProgress = false
+              return
+            }
+            data.error = null
+            data.step = Math.min(data.step + 1, data.integrations.length)
+          }
+        } else {
+          data.inProgress = false
+          data.error = { message: errorMessage }
+          return
+        }
+      }
     }
+
+    data.inProgress = false
   }
 }
 

--- a/src/partials/integrations/bulk-actions-modal.hbs
+++ b/src/partials/integrations/bulk-actions-modal.hbs
@@ -26,7 +26,7 @@
           </p>
           <div class="flex justify-between my-4 text-sm font-medium">
             <span x-show="(!inProgress && !error) || done === integrations.length"></span>
-            <span class="text-purple-700 dark:text-white" :class="{ 'animate-pulse': inProgress }" x-show="inProgress && done < integrations.length">
+            <span class="text-purple-700 dark:text-white" x-show="inProgress && done < integrations.length && !awaitingContinue">
                 <span class="capitalize" x-text="operation"></span>ing Integration/<span x-text="currentIntegration?.id"></span>...
               </span>
             <span class="text-red-800 dark:text-red-400" x-show="error">
@@ -38,9 +38,8 @@
               </span>
             </span>
           </div>
-          <div class="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700"
-               :class="{ 'animate-pulse': inProgress  && done < integrations.length}">
-            <div class="bg-purple-600 h-2.5 rounded-full" :style="`width: ${done/integrations.length*100}%`"></div>
+          <div class="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
+            <div class="bg-purple-600 h-2.5 rounded-full" :style="`width: ${step/integrations.length*100}%`"></div>
           </div>
         </div>
         <!-- Logs -->
@@ -75,16 +74,22 @@
         </button>
         <button class="py-2.5 px-5 me-2 text-sm font-medium text-gray-900 bg-white rounded-lg border border-gray-200 cursor-not-allowed focus:z-10 focus:ring-4 focus:outline-none focus:ring-purple-700 focus:text-purple-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 inline-flex items-center"
                 type="button" disabled
-                x-show="inProgress && done < integrations.length">
+                x-show="inProgress && done < integrations.length && !awaitingContinue">
           <svg aria-hidden="true" role="status" class="inline w-4 h-4 me-3 text-gray-200 animate-spin dark:text-gray-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
             <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="#1C64F2"/>
           </svg>
           <span class="capitalize" x-text="operation"></span>ing...
         </button>
+        <button type="button"
+                class="text-white bg-purple-700 hover:bg-purple-800 focus:ring-4 focus:outline-none focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-800"
+                x-show="awaitingContinue"
+                @click="_continueResolver(true); awaitingContinue = false">
+          Continue
+        </button>
         <button class="text-white bg-purple-700 hover:bg-purple-800 focus:ring-4 focus:outline-none focus:ring-purple-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-purple-600 dark:hover:bg-purple-700 dark:focus:ring-purple-800"
                 type="button"
-                x-show="!inProgress && !(error || done === integrations.length)"
+                x-show="!inProgress && step === 0"
                 @click="await batchIntegrationOperations(data)">
           <span class="capitalize" x-text="operation"></span>
         </button>

--- a/src/partials/integrations/bulk-actions-modal.hbs
+++ b/src/partials/integrations/bulk-actions-modal.hbs
@@ -24,15 +24,17 @@
             Perform <span class="font-bold dark:text-white" x-text="operation"></span> operation on selected
             integrations.
           </p>
-          <div class="flex justify-between my-4 text-sm font-medium">
-            <span x-show="(!inProgress && !error) || done === integrations.length"></span>
-            <span class="text-purple-700 dark:text-white" x-show="inProgress && done < integrations.length && !awaitingContinue">
-                <span class="capitalize" x-text="operation"></span>ing Integration/<span x-text="currentIntegration?.id"></span>...
+          <div class="flex justify-between items-center my-4 text-sm font-medium gap-4">
+            <div class="flex-1 min-w-0">
+              <span x-show="(!inProgress && !error) || done === integrations.length"></span>
+              <span class="text-purple-700 dark:text-white" x-show="inProgress && done < integrations.length && !awaitingContinue">
+                <span class="capitalize" x-text="operation"></span>ing <span x-text="currentIntegration?.id"></span> (<span x-text="currentIntegration?.practice?.name"></span> - <span class="uppercase" x-text="currentIntegration?.providerConfiguration?.providerId"></span>)...
               </span>
-            <span class="text-red-800 dark:text-red-400" x-show="error">
-              <span x-text="error?.message"></span>
-            </span>
-            <span class="text-purple-700 dark:text-white">
+              <span class="text-red-800 dark:text-red-400" x-show="error">
+                <span x-text="error?.message"></span>
+              </span>
+            </div>
+            <span class="flex-shrink-0 text-purple-700 dark:text-white">
               <span :class="{'text-red-800 dark:text-red-400': error}">
                 <span x-text="step"></span> of <span x-text="integrations.length"></span>
               </span>

--- a/src/partials/integrations/modal.hbs
+++ b/src/partials/integrations/modal.hbs
@@ -22,7 +22,7 @@
           <p class="text-sm text-gray-700 dark:text-gray-400">
             This will test the credentials for Integration
             <strong><span x-text="integration?.id"></span>
-              (<span class="uppercase" x-text="integration?.providerConfiguration.providerId"></span>)</strong>.<br>
+              (<span x-text="integration?.practice?.name"></span> - <span class="uppercase" x-text="integration?.providerConfiguration.providerId"></span>)</strong>.<br>
             Are you sure?
           </p>
         </template>
@@ -30,7 +30,7 @@
           <p class="text-sm text-gray-700 dark:text-gray-400">
             This will <span x-text="operation"></span> Integration
             <strong><span x-text="integration?.id"></span>
-              (<span class="uppercase" x-text="integration?.providerConfiguration.providerId"></span>)</strong>
+              (<span x-text="integration?.practice?.name"></span> - <span class="uppercase" x-text="integration?.providerConfiguration.providerId"></span>)</strong>
             and
             <span x-text="operation"></span> all
             running jobs.<br>

--- a/src/partials/integrations/modal.hbs
+++ b/src/partials/integrations/modal.hbs
@@ -18,15 +18,29 @@
       </div>
       <!-- Modal body -->
       <div class="mt-4 mb-6">
-        <p class="text-sm text-gray-700 dark:text-gray-400">
-          This will <span x-text="operation"></span> Integration
-          <strong><span x-text="integration?.id"></span>
-            (<span class="uppercase" x-text="integration?.providerConfiguration.providerId"></span>)</strong>
-          and
-          <span x-text="operation"></span> all
-          running jobs.<br>
-          Are you sure?
-        </p>
+        <template x-if="operation === 'test'">
+          <p class="text-sm text-gray-700 dark:text-gray-400">
+            This will test the credentials for Integration
+            <strong><span x-text="integration?.id"></span>
+              (<span class="uppercase" x-text="integration?.providerConfiguration.providerId"></span>)</strong>.<br>
+            Are you sure?
+          </p>
+        </template>
+        <template x-if="operation !== 'test'">
+          <p class="text-sm text-gray-700 dark:text-gray-400">
+            This will <span x-text="operation"></span> Integration
+            <strong><span x-text="integration?.id"></span>
+              (<span class="uppercase" x-text="integration?.providerConfiguration.providerId"></span>)</strong>
+            and
+            <span x-text="operation"></span> all
+            running jobs.<br>
+            Are you sure?
+          </p>
+        </template>
+        <div class="flex items-center p-4 mt-4 text-sm text-green-800 border border-green-300 rounded-lg bg-green-50 dark:bg-gray-800 dark:text-green-400 dark:border-green-800"
+             role="alert" x-show="result?.ok">
+          Credentials tested successfully.
+        </div>
       </div>
       <!-- Modal footer -->
       <div class="flex items-center p-4 my-4 text-sm text-red-800 border border-red-300 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400 dark:border-red-800" role="alert"

--- a/src/partials/integrations/table.hbs
+++ b/src/partials/integrations/table.hbs
@@ -12,7 +12,7 @@
         <th class="px-4 py-3 w-[8rem]">Provider</th>
         <th class="px-4 py-3 text-center w-32">Status</th>
         <template x-if="actions">
-          <th class="px-4 py-3 text-center w-44">Actions</th>
+          <th class="px-4 py-3 text-center w-56">Actions</th>
         </template>
       </tr>
     {{/inline}}
@@ -47,7 +47,7 @@
           <template x-if="actions">
             <td class="px-4 py-3 text-xs">
               <div class="flex items-center space-x-4 text-sm">
-                <ul class="flex flex-wrap items-center justify-center font-xs font-semibold text-purple-600 dark:text-gray-400">
+                <ul class="flex items-center justify-center font-xs font-semibold text-purple-600 dark:text-gray-400">
                   <template x-for="operation in integration.operations">
                     <li>
                       <a href="#" class="me-4 hover:underline capitalize"


### PR DESCRIPTION
## Summary

  When running a batch integration test, if one integration fails the process now pauses instead of stopping. The error message is displayed under the progress bar (e.g. `11ec4bb1-... (Conn - Graham -         
  ANTECH-V6): Failed to authenticate`) and a **Continue** button appears in the footer, letting the user decide whether to keep testing the remaining integrations or dismiss the modal to stop.
                                                                                                                                                                                                                 
  Additionally, a **Test** action has been added to each integration row in the table, allowing users to test a single integration's credentials without running a batch operation. On success, a green banner is
   shown inside the modal; on failure, the existing red error banner appears, with the action button remaining available to retry.
                                                                                                                                                                                                                 
  ## Implementation         

  - **`js/integrations.js`**: Restructured `batchIntegrationOperations` to catch errors per-integration inside the loop instead of wrapping the whole loop in a single try/catch. For `test` operations, on      
  failure it sets `data.error` and `data.awaitingContinue = true`, then suspends execution via a `Promise` that resolves when the user clicks **Continue** or dismisses the modal. On continue, the error is
  cleared and the loop proceeds to the next integration. The `onHide` callback was updated to resolve the pending promise with `false` if the modal is dismissed while paused, preventing the async loop from    
  hanging. Start/Stop/Restart operations retain the original behavior of stopping on first error. Log entries now use `{id} ({practice} - PROVIDER)` format and report `Authentication successful` on success.

  - **`src/partials/integrations/bulk-actions-modal.hbs`**: The spinner is hidden while awaiting user input (`!awaitingContinue`). A **Continue** button is shown via `x-show="awaitingContinue"`. The progress  
  bar width now uses `step` (items attempted) instead of `done` (items succeeded), so failures still advance the bar and it reaches 100% when all integrations have been processed. The action button visibility
  was changed from `!inProgress && !(error || done === integrations.length)` to `!inProgress && step === 0`, so it disappears as soon as the batch starts and never reappears after completion. Status text and  
  log entries now include the practice name alongside the integration ID and provider. Fixed a layout issue where the "X of Y" counter would wrap to a new line on long error messages.

  - **`js/constants/integrations-config.js`**: Added `test` as the first operation for all integration statuses (RUNNING, STOPPED, NEW), so a **Test** link always appears first in the Actions column.          
   
  - **`src/partials/integrations/modal.hbs`**: Added a conditional body for `test` operations with integration-specific confirmation text and a green success banner. Updated the integration identifier format  
  from `{id} (PROVIDER)` to `{id} ({practice} - PROVIDER)` throughout.
                                                                                                                                                                                                                 
  - **`src/partials/integrations/table.hbs`**: Widened the Actions column and removed `flex-wrap` to prevent action links from wrapping across rows.                                                             
   
  Closes https://github.com/nominal-systems/dmi-api-admin-ui/issues/102 and https://github.com/nominal-systems/dmi-api-admin-ui/issues/103                                                                                                                                          
