### PR TITLE
Improve modal handling for external requests

### DIFF
--- a/js/external-requests.js
+++ b/js/external-requests.js
@@ -96,18 +96,16 @@ export const externalRequests = () => {
     // Modal
     modal: modal({
       ref: 'externalRequestModal',
-      onHide: (component) => {
-        component.externalRequest = null
-      }
     }),
     async openModal(externalRequest) {
+      this.externalRequest = null
       const req = await getExternalRequest(externalRequest._id)
       req.statusText = mapHttpStatusText(req.status)
       req.providerLabel = getProviderConfig(req.provider).label
       this.externalRequest = req
       this.modal.open()
     },
-    externalRequest: {},
+    externalRequest: null,
 
     init() {
       Alpine.store('title').set('External Requests')

--- a/src/partials/external-requests/modal.hbs
+++ b/src/partials/external-requests/modal.hbs
@@ -25,8 +25,8 @@
       </div>
 
       <!-- Modal body -->
-      <template x-if="externalRequest !== undefined">
-        <div class="mt-4 mb-6" x-data="externalRequest">
+      <template x-if="externalRequest">
+        <div class="mt-4 mb-6">
           {{> external-requests/detail }}
         </div>
       </template>


### PR DESCRIPTION
  Fix external request modal showing Invalid Date after first open                                                                                                                                               
                                                                  
  Closes #105                                                                                                                                                                                                    
                                                                                                                                                                                                                 
  Summary
                                                                                                                                                                                                                 
  - Remove onHide callback that was creating a shadow property on the modal plugin's reactive proxy, permanently hiding the outer scope's externalRequest                                                        
  - Reset externalRequest to null at the start of openModal instead, ensuring proper x-if template teardown between opens
  - Remove unnecessary x-data="externalRequest" wrapper in the modal template                                                                                                                                    
                                                                                                                                                                                                                 
  Context                                                                                                                                                                                                        
                                                                                                                                                                                                                 
  Regression from cfcaea0 — moving Modal creation from init() to lazy _initModal() changed the this context captured by the onHide closure, causing property sets to land on the wrong scope object.             
