### PR TITLE
Improve modal handling for events

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -93,15 +93,11 @@ export const events = {
   ),
 
   // Modal
-  modal: modal(
-    {
-      ref: 'eventModal',
-      onHide: (component) => {
-        component.event = null
-      }
-    }
-  ),
+  modal: modal({
+    ref: 'eventModal'
+  }),
   async openModal(ev) {
+    this.event = null
     this.event = await getEvent(ev._id)
     this.modal.open()
   },

--- a/src/partials/events/modal.hbs
+++ b/src/partials/events/modal.hbs
@@ -18,7 +18,7 @@
         </button>
       </div>
       <!-- Modal body -->
-      <template x-if="event !== undefined">
+      <template x-if="event">
         <div class="mt-4 mb-6">
           <template x-if="event?.data !== undefined">
             <div x-data="event.data">


### PR DESCRIPTION
Fix event detail modal showing empty details after first open

Closes #109

Summary

- Remove onHide callback that was creating a shadow property on the modal plugin's reactive proxy, permanently hiding the outer scope's event
- Reset event to null at the start of openModal instead, ensuring proper x-if template teardown between opens
- Change x-if="event !== undefined" to x-if="event" so the template properly toggles on truthy values

Context

Same root cause as #105 — moving Modal creation from init() to lazy _initModal() changed the this context captured by the onHide closure, causing property sets to land on the wrong scope object.