### PR TITLE
Add hover tooltip with integration options in integrations table

### DIFF
--- a/js/integrations.js
+++ b/js/integrations.js
@@ -30,6 +30,10 @@ export const integrations = {
         integration.providerLabel = getProviderConfig(integration.providerConfiguration.providerId).label
         integration.operations = integrationConfig.operations
         integration.color = integrationConfig.color
+        integration.tooltipData = Object.entries(integration.integrationOptions || {})
+          .filter(([key]) => !key.toLowerCase().includes('password'))
+          .map(([key, value]) => ({ key, value: String(value) }))
+        integration._showTooltip = false
       })
     },
     filter: {

--- a/src/partials/integrations/table.hbs
+++ b/src/partials/integrations/table.hbs
@@ -25,7 +25,32 @@
                    type="checkbox" value="" x-model="integration._checked"
                    @change="selectionUpdated(integration)">
           </th>
-          <td class="px-4 py-3 text-xs" x-text="integration.id"></td>
+          <td class="px-4 py-3 text-xs">
+            <div class="flex items-center gap-1.5">
+              <span x-text="integration.id"></span>
+              <template x-if="integration.tooltipData && integration.tooltipData.length > 0">
+                <div class="relative flex-shrink-0">
+                  <span class="text-gray-400 hover:text-blue-500 dark:text-gray-500 dark:hover:text-blue-400 cursor-default"
+                        @mouseenter="integration._showTooltip = true"
+                        @mouseleave="integration._showTooltip = false">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                  </span>
+                  <div x-show="integration._showTooltip"
+                       x-cloak
+                       class="absolute z-50 left-5 top-0 w-56 text-xs text-white bg-gray-900 dark:bg-gray-700 rounded-lg shadow-lg p-2">
+                    <template x-for="item in integration.tooltipData" :key="item.key">
+                      <div class="flex justify-between gap-2 py-0.5">
+                        <span class="text-gray-400 truncate" x-text="item.key"></span>
+                        <span class="font-medium truncate" x-text="item.value"></span>
+                      </div>
+                    </template>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </td>
           <td class="px-4 py-3 truncate">
             <div class="flex items-center">
               <div>


### PR DESCRIPTION
## Summary

- Adds an info icon (ℹ) next to each integration ID in the integrations table
- On hover, a tooltip reveals all non-sensitive `integrationOptions` fields as key-value pairs
- Fields containing "password" in the key name are filtered out; everything else is shown
- Dark mode supported via `bg-gray-900 dark:bg-gray-700` tooltip styling
- Icon is a plain `<span>` — no link, no click action

## Implementation notes

- Tooltip state (`_showTooltip`) and data (`tooltipData`) are computed in `processResults` and attached directly to each integration object, keeping it consistent with how `color`, `operations`, and `providerLabel` are handled
- No backend changes — `integrationOptions` is already returned by `GET /integrations`

Closes #112