### PR TITLE
feat: show integrationId in external request and internal event logs

### DIFF
--- a/js/external-requests.js
+++ b/js/external-requests.js
@@ -1,5 +1,5 @@
 import Alpine from 'alpinejs'
-import { getExternalRequest, getExternalRequests, getProviders } from './api-client'
+import { getExternalRequest, getExternalRequests, getIntegration, getProviders } from './api-client'
 import table from './plugins/table'
 import { getProviderConfig, getQueryParams, mapHttpStatusText } from './common/utils'
 import moment from 'moment'
@@ -102,6 +102,13 @@ export const externalRequests = () => {
       const req = await getExternalRequest(externalRequest._id)
       req.statusText = mapHttpStatusText(req.status)
       req.providerLabel = getProviderConfig(req.provider).label
+      if (req.integrationId) {
+        try {
+          req.integration = await getIntegration(req.integrationId)
+        } catch (e) {
+          // Integration might not exist
+        }
+      }
       this.externalRequest = req
       this.modal.open()
     },

--- a/src/partials/external-requests/detail.hbs
+++ b/src/partials/external-requests/detail.hbs
@@ -1,3 +1,21 @@
+<template x-if="externalRequest?.integrationId">
+  <div class="mb-4">
+    <h4 class="text-lg mb-3 font-semibold text-gray-900 dark:text-white">
+      Integration
+    </h4>
+    <p class="text-sm text-left">
+      <template x-if="externalRequest.integration?.practice?.name">
+        <span class="text-gray-700 dark:text-gray-200">
+          <span x-text="externalRequest.integration.practice.name"></span> -
+          (<a :href="'/ui/integrations/' + externalRequest.integrationId" class="text-blue-600 dark:text-blue-400 hover:underline" x-text="externalRequest.integrationId"></a>)
+        </span>
+      </template>
+      <template x-if="!externalRequest.integration?.practice?.name">
+        <a :href="'/ui/integrations/' + externalRequest.integrationId" class="text-blue-600 dark:text-blue-400 hover:underline" x-text="externalRequest.integrationId"></a>
+      </template>
+    </p>
+  </div>
+</template>
 <div class="mb-4">
   <h4 class="text-lg mb-3 font-semibold text-gray-900 dark:text-white">
     Request

--- a/src/partials/internal-events/detail.hbs
+++ b/src/partials/internal-events/detail.hbs
@@ -7,6 +7,14 @@
     <dt class="mb-1 text-gray-500 md:text-sm dark:text-gray-400">Pattern</dt>
     <dd class="text-sm font-semibold" x-text="event.pattern"></dd>
   </div>
+  <template x-if="event.integrationId">
+    <div class="flex flex-col py-3">
+      <dt class="mb-1 text-gray-500 md:text-sm dark:text-gray-400">Integration</dt>
+      <dd class="text-sm font-semibold">
+        <a :href="'/ui/integrations/' + event.integrationId" class="text-blue-600 dark:text-blue-400 hover:underline" x-text="event.integrationId"></a>
+      </dd>
+    </div>
+  </template>
   <div class="flex flex-col pt-3">
     <dt class="mb-1 text-gray-500 md:text-sm dark:text-gray-400">Data</dt>
     <dd class="text-sm font-semibold">

--- a/src/partials/transaction-logs/external-request.hbs
+++ b/src/partials/transaction-logs/external-request.hbs
@@ -14,6 +14,11 @@
   <span class="flex flex-none items-center text-xs font-medium text-gray-900 dark:text-white me-3 ml-4">
     <span class="flex w-2.5 h-2.5 rounded-full me-1.5 flex-shrink-0" :class="`bg-${tag.color}-500`"></span><span x-text="tag.label"></span>
   </span>
+  <template x-if="data.integrationId">
+    <a :href="'/ui/integrations/' + data.integrationId" class="ml-2 text-xs bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300 px-2 py-0.5 rounded hover:bg-purple-200 dark:hover:bg-purple-800">
+      Integration
+    </a>
+  </template>
 </div>
 
 <div class="bg-green-500 dark:bg-green-500"></div>

--- a/src/partials/transaction-logs/internal-event.hbs
+++ b/src/partials/transaction-logs/internal-event.hbs
@@ -7,4 +7,9 @@
   <div class="text-sm font-normal ml-2 text-gray-500 dark:text-gray-300">
     <span>Internal API Event</span>
   </div>
+  <template x-if="data.integrationId">
+    <a :href="'/ui/integrations/' + data.integrationId" class="ml-2 text-xs bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300 px-2 py-0.5 rounded hover:bg-purple-200 dark:hover:bg-purple-800">
+      Integration
+    </a>
+  </template>
 </div>


### PR DESCRIPTION
Closes #93

- Show integration details (with practice name when available) in external request modal
- Add integrationId link to internal event detail view
- Add integration badges to transaction logs for both external requests and internal events
- Gracefully handles missing integrationId for backwards compatibility with old logs