### PR TITLE
Show practice and integration details in external requests

### DIFF
--- a/js/external-requests.js
+++ b/js/external-requests.js
@@ -1,11 +1,15 @@
 import Alpine from 'alpinejs'
-import { getExternalRequest, getExternalRequests, getProviders } from './api-client'
+import { getExternalRequest, getExternalRequests, getPractices, getProviders } from './api-client'
 import table from './plugins/table'
-import { getProviderConfig, getQueryParams, mapHttpStatusText } from './common/utils'
+import { getProviderConfig, getQueryParams, isNullOrUndefined, mapHttpStatusText } from './common/utils'
 import moment from 'moment'
 import { DATE_FORMAT } from './constants/date-format'
 import modal from './plugins/modal'
 import { parseDateRange } from './common/date-utils'
+import config from './config'
+
+const integrationUrl = (integrationId) =>
+  integrationId ? `${config.get('UI_BASE')}/integrations/${integrationId}` : null
 
 export const externalRequests = () => {
   return {
@@ -22,9 +26,18 @@ export const externalRequests = () => {
 
         return await getExternalRequests(providers, status, method, date, page, pageSize)
       },
-      processResults: (externalRequests) => {
+      processResults: async (externalRequests) => {
+        const practiceIds = [...new Set(
+          externalRequests
+            .filter((req) => !isNullOrUndefined(req.practiceId))
+            .map((req) => req.practiceId)
+        )]
+        const practices = practiceIds.length
+          ? (await getPractices({ ids: practiceIds }, 1, 1000)).data
+          : []
         externalRequests.forEach((req) => {
           req.providerLabel = getProviderConfig(req.provider).label
+          req.practice = practices.find((practice) => practice.id === req.practiceId) || {}
         })
       },
       filter: {
@@ -102,6 +115,8 @@ export const externalRequests = () => {
       const req = await getExternalRequest(externalRequest._id)
       req.statusText = mapHttpStatusText(req.status)
       req.providerLabel = getProviderConfig(req.provider).label
+      req.practice = externalRequest.practice
+      req.integrationUrl = integrationUrl(req.integrationId)
       this.externalRequest = req
       this.modal.open()
     },

--- a/src/pages/external-requests.hbs
+++ b/src/pages/external-requests.hbs
@@ -17,6 +17,9 @@
             <th scope="col" class="px-6 py-3 w-36">
               Provider
             </th>
+            <th scope="col" class="px-6 py-3 w-56">
+              Practice
+            </th>
             <th scope="col" class="px-6 py-3 w-24">
               Method
             </th>
@@ -39,6 +42,8 @@
               <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
                   x-text="req.providerLabel">
               </th>
+              <td class="px-6 py-4 truncate" x-text="req.practice?.name">
+              </td>
               <td class="px-6 py-4" x-text="req.method">
               </td>
               <td class="px-6 py-4 truncate" x-text="req.url">

--- a/src/partials/external-requests/detail.hbs
+++ b/src/partials/external-requests/detail.hbs
@@ -1,3 +1,23 @@
+<template x-if="externalRequest?.practice?.name || externalRequest?.integrationId">
+  <dl class="mb-4 grid grid-cols-2 gap-4">
+    <template x-if="externalRequest?.practice?.name">
+      <div>
+        <dt class="mb-1 text-gray-500 md:text-sm dark:text-gray-400">Practice</dt>
+        <dd class="text-sm font-semibold text-gray-900 dark:text-white" x-text="externalRequest.practice.name"></dd>
+      </div>
+    </template>
+    <template x-if="externalRequest?.integrationId">
+      <div>
+        <dt class="mb-1 text-gray-500 md:text-sm dark:text-gray-400">Integration</dt>
+        <dd class="text-sm font-semibold">
+          <a :href="externalRequest.integrationUrl"
+             class="text-blue-600 dark:text-blue-500 hover:underline"
+             x-text="externalRequest.integrationId"></a>
+        </dd>
+      </div>
+    </template>
+  </dl>
+</template>
 <div class="mb-4">
   <h4 class="text-lg mb-3 font-semibold text-gray-900 dark:text-white">
     Request


### PR DESCRIPTION
## Summary

Surfaces the originating practice and integration of each external request, so error logs are traceable to their source.

- **List:** new **Practice** column (practice name), resolved in a single batched `getPractices({ ids })` call.
- **Detail modal:** new **Practice / Integration** block showing the practice name and the full `integrationId`, linked to `/integrations/:id`.

Practice/integration data comes from the `practiceId`/`integrationId` fields added to `external_requests_v2` in dmi-api (umbrella dmi-api#302). Fields are optional, so the UI degrades gracefully when they are absent.

## Notes

- Supersedes #114 with a reworked, narrower approach (batched practice lookup + Practice column + practice in the modal) on top of current `main`. #114 will be closed separately.
- Search by practice is intentionally left out of this PR; it requires a backend `search` param on `GET /external-requests` and will be added later.
- Depends on the dmi-api receptor changes (dmi-api#302) for the fields to be populated against a real environment.

Closes #93