### PR TITLE
Show error state instead of infinite spinner on Transaction Logs when a query fails

### DIFF
--- a/js/transaction-logs.js
+++ b/js/transaction-logs.js
@@ -27,8 +27,8 @@ export default () => {
       const queryParams = getQueryParams()
       this.accessionId = queryParams.accessionId?.toUpperCase()
       Alpine.store('title').set(`Transaction Logs for ${this.accessionId}`)
-      const transactionLogs = await getTransactionLogs(this.accessionId)
-      if (transactionLogs.errors === undefined) {
+      try {
+        const transactionLogs = await getTransactionLogs(this.accessionId)
         transactionLogs.forEach(log => {
           log.timestamp = new Date(log.timestamp).toLocaleString()
           log.message = buildMessage(log)
@@ -38,8 +38,9 @@ export default () => {
           }
         })
         this.logs = transactionLogs
-      } else {
-        this.error = transactionLogs.message
+      } catch (err) {
+        if (err.redirected) return
+        this.error = err
       }
       this.doFilter();
     }

--- a/src/pages/transaction-logs.hbs
+++ b/src/pages/transaction-logs.hbs
@@ -26,11 +26,19 @@
           <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"/>
         </svg>
         <span class="sr-only">Info</span>
-        <div>
-          <span class="font-semibold">Order not found:</span> No order with Accession ID
-          '<span class="underline decoration-red-400 decoration-2 underline-offset-2" x-text="accessionId"></span>' was
-          found.
-        </div>
+        <template x-if="error.status === 404">
+          <div>
+            <span class="font-semibold">Order not found:</span> No order with Accession ID
+            '<span class="underline decoration-red-400 decoration-2 underline-offset-2" x-text="accessionId"></span>' was
+            found.
+          </div>
+        </template>
+        <template x-if="error.status !== 404">
+          <div>
+            <span class="font-semibold">Something went wrong</span> loading the transaction logs. Please retry.
+            <span x-show="error.message" class="block mt-1 text-xs opacity-75" x-text="error.message"></span>
+          </div>
+        </template>
       </div>
     </template>
 


### PR DESCRIPTION
## What

Fix the Transaction Logs page hanging on an infinite loading spinner when the data request fails, and render a proper error state instead.

## Background

Opening a Transaction Logs URL for an accession with no order/report (`GET /admin/transaction-logs?accessionId=<...>` returns HTTP 404) left the page stuck on the loading spinner forever, with nothing telling the user what happened — it looked like the page had hung.

Root cause: the component assumed the api-client *returns* an error object, but the current api-client *throws* on non-2xx responses:

- `js/api-client.js` (`apiRequest`) throws on `!response.ok`, attaching `error.status` / `error.message`.
- `js/transaction-logs.js` `init()` awaited `getTransactionLogs(...)` with no try/catch, then checked `if (logs.errors === undefined)` — dead legacy logic. On failure the `await` threw, the exception escaped `init()` uncaught, `this.error` was never set and `this.logs` stayed empty.
- `src/pages/transaction-logs.hbs` shows the spinner while `!error && !logs.length`, which stayed true forever. The page already had an error `<template>` (hardcoded "Order not found") that never activated because `this.error` was never set.

## Approach

- `js/transaction-logs.js`: wrap the fetch in `try/catch`, set `this.error = err` on failure, and drop the dead `logs.errors` branch. Skip setting the error when `err.redirected` is set (the api-client already navigated to login).
- `src/pages/transaction-logs.hbs`: branch the error block on status:
  - **404** → existing "No order with Accession ID '…' was found." message.
  - **Any other status (5xx / network / etc.)** → generic "Something went wrong loading the transaction logs. Please retry.", with `error.message` shown as secondary detail. Raw API messages are not used as the primary text.

## Safety

- Additive/behavioral change scoped to the Transaction Logs page (`transaction-logs.js` + `transaction-logs.hbs`); no shared layout or api-client changes.
- Success path is unchanged.
- This is a different code path from the shared-table error state tracked in #118 (there the error is captured by `table.js` but never rendered); that remains a separate fix.

## Tests

- `UI_URL=/ui npm run build` passes.
- Manually verified against a real 5xx: a stale local DB (missing `order.orphan` column) made the endpoint return HTTP 500 — the page now shows the generic error message instead of spinning.

## Caveats

- Pre-existing unused-variable warning in `transaction-logs.js` (`buildMessage`) is left untouched as it's unrelated to this change.

Closes #76
